### PR TITLE
#13 - refactor: update Copy() function and interface implementations

### DIFF
--- a/cmp_cases_test.go
+++ b/cmp_cases_test.go
@@ -368,6 +368,11 @@ func getMinCases[C any](builder testCollectionBuilder[C]) []testCase[C, int] {
 			want1: 111,
 		},
 		{
+			name:  "Min() on three-item collection reversed",
+			coll:  builder.ThreeRev(),
+			want1: 111,
+		},
+		{
 			name:  "Min() on six-item collection",
 			coll:  builder.SixWithDuplicates(),
 			want1: 111,

--- a/definitions.go
+++ b/definitions.go
@@ -34,15 +34,6 @@ type Comparator[V any] = func(a, b V) int
 // PairComparator is a comparator function for key-value pairs.
 type PairComparator[K comparable, V any] = Comparator[Pair[K, V]]
 
-// KKVistor is a visitor function for key-value pairs.
-type KVVistor[K comparable, V any] = func(i int, k K, val V)
-
-// KVPredicate is a predicate function for key-value pairs.
-type KVPredicate[K comparable, V any] = func(i int, k K, val V) (valid bool)
-
-// KVReducer is a reducer function for key-value pairs.
-type KVReducer[K comparable, V any] = func(keyAcc K, valueAcc V, currentKey K, currentValue V) (K, V)
-
 // Base is the base interface for all collections.
 type Base[V any] interface {
 	// Contains returns true if the collection contains an element that matches the predicate.

--- a/definitions_internal.go
+++ b/definitions_internal.go
@@ -9,7 +9,7 @@ import (
 
 type baseInternal[V any] interface {
 	Base[V]
-	copy() Base[V]
+	copy() baseInternal[V]
 	// values() iter.Seq[V] // TODO
 }
 
@@ -65,7 +65,7 @@ type listInternal[V any] interface {
 
 type mapInternal[K comparable, V any] interface {
 	Map[K, V]
-	copy() mapInternal[K, V]
+	baseInternal[Pair[K, V]]
 	// keyValues() iter.Seq2[K, V] // TODO
 	prependAll(pairs []Pair[K, V])
 	remove(k K)

--- a/functions.go
+++ b/functions.go
@@ -3,8 +3,12 @@ package coll
 // Public:
 
 // Copy creates a copy of the given collection.
-func Copy[C baseInternal[V], V any](c C) C {
-	return c.copy().(C)
+func Copy[C Base[V], V any](coll C) C {
+	// check if c is of type baseInternal[T]:
+	if c, ok := any(coll).(baseInternal[V]); ok {
+		return c.copy().(C)
+	}
+	panic("Copy() requires a collection that implements the baseInternal interface")
 }
 
 //// Filter creates a new, filtered collection from the given collection.

--- a/functions_internal.go
+++ b/functions_internal.go
@@ -32,26 +32,6 @@ func comfyContains[C Base[V], V any](coll C, predicate Predicate[V]) bool {
 	return found
 }
 
-func comfyContainsValue[C Base[V], V cmp.Ordered](coll C, search V) bool {
-	return comfyContains(coll, func(_ int, v V) bool {
-		return v == search
-	})
-}
-
-func comfyContainsKV[M Map[K, V], K comparable, V any](m M, predicate KVPredicate[K, V]) bool {
-	found := false
-	m.EachUntil(func(i int, p Pair[K, V]) bool {
-		if predicate(i, p.Key(), p.Val()) {
-			found = true
-			return false
-		}
-
-		return true
-	})
-
-	return found
-}
-
 func comfyCount[C Base[V], V any](coll C, predicate Predicate[V]) int {
 	count := 0
 	coll.Each(func(i int, v V) {

--- a/functions_test.go
+++ b/functions_test.go
@@ -57,7 +57,7 @@ func (*baseFakeWithoutInternal[V]) Values() iter.Seq[V] {
 func Test_Copy_forEachFlatCollection(t *testing.T) {
 	cases := []struct {
 		name string
-		coll Base[int]
+		coll LinearMutable[int]
 	}{
 		{
 			name: "Copy() on empty Sequence",
@@ -80,7 +80,15 @@ func Test_Copy_forEachFlatCollection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Copy(tt.coll)
 			if !reflect.DeepEqual(got, tt.coll) {
-				t.Errorf("Copy() = %v, want1 %v", got, tt.coll)
+				t.Errorf("Copy() = %v, want %v", got, tt.coll)
+			}
+
+			tt.coll.Append(999)
+			if reflect.DeepEqual(got, tt.coll) {
+				t.Errorf("Copy() did not create a deep copy")
+			}
+			if got.Len() == tt.coll.Len() {
+				t.Errorf("Original length changed: got %d, want 3", got.Len())
 			}
 		})
 	}
@@ -103,12 +111,24 @@ func Test_Copy_forEachMap(t *testing.T) {
 				NewPair(3, 333),
 			}),
 		},
+		{
+			name: "Copy() on empty CmpMap",
+			coll: NewCmpMap[int, int](),
+		},
+		{
+			name: "Copy() three-item CmpMap",
+			coll: NewCmpMapFrom([]Pair[int, int]{
+				NewPair(1, 111),
+				NewPair(2, 222),
+				NewPair(3, 333),
+			}),
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Copy(tt.coll)
 			if !reflect.DeepEqual(got, tt.coll) {
-				t.Errorf("Copy() = %v, want1 %v", got, tt.coll)
+				t.Errorf("Copy() = %v, want %v", got, tt.coll)
 			}
 		})
 	}

--- a/functions_test.go
+++ b/functions_test.go
@@ -1,0 +1,131 @@
+package coll
+
+import (
+	"iter"
+	"reflect"
+	"testing"
+)
+
+type baseFakeWithoutInternal[V any] struct{}
+
+func (*baseFakeWithoutInternal[V]) Contains(_ Predicate[V]) bool {
+	return false
+}
+
+func (*baseFakeWithoutInternal[V]) Count(_ Predicate[V]) int {
+	return 0
+}
+
+func (*baseFakeWithoutInternal[V]) Each(_ Visitor[V]) {
+}
+
+func (*baseFakeWithoutInternal[V]) EachUntil(_ Predicate[V]) {
+}
+
+func (*baseFakeWithoutInternal[V]) Find(_ Predicate[V], defaultValue V) V {
+	return defaultValue
+}
+
+func (*baseFakeWithoutInternal[V]) Fold(_ Reducer[V], initial V) (result V) {
+	return initial
+}
+
+func (*baseFakeWithoutInternal[V]) IsEmpty() bool {
+	return true
+}
+
+func (*baseFakeWithoutInternal[V]) Len() int {
+	return 0
+}
+
+func (*baseFakeWithoutInternal[V]) Search(_ Predicate[V]) (val V, found bool) {
+	return val, false
+}
+
+func (*baseFakeWithoutInternal[V]) Reduce(_ Reducer[V]) (result V, err error) {
+	return result, nil
+}
+
+func (*baseFakeWithoutInternal[V]) ToSlice() []V {
+	return nil
+}
+
+func (*baseFakeWithoutInternal[V]) Values() iter.Seq[V] {
+	return nil
+}
+
+func Test_Copy_forEachFlatCollection(t *testing.T) {
+	cases := []struct {
+		name string
+		coll Base[int]
+	}{
+		{
+			name: "Copy() on empty Sequence",
+			coll: NewSequence[int](),
+		},
+		{
+			name: "Copy() three-item sequence",
+			coll: NewSequenceFrom([]int{111, 222, 333}),
+		},
+		{
+			name: "Copy() on empty CmpSequence",
+			coll: NewCmpSequence[int](),
+		},
+		{
+			name: "Copy() three-item CmpSequence",
+			coll: NewCmpSequenceFrom([]int{111, 222, 333}),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Copy(tt.coll)
+			if !reflect.DeepEqual(got, tt.coll) {
+				t.Errorf("Copy() = %v, want1 %v", got, tt.coll)
+			}
+		})
+	}
+}
+
+func Test_Copy_forEachMap(t *testing.T) {
+	cases := []struct {
+		name string
+		coll Map[int, int]
+	}{
+		{
+			name: "Copy() on empty Map",
+			coll: NewMap[int, int](),
+		},
+		{
+			name: "Copy() three-item Map",
+			coll: NewMapFrom([]Pair[int, int]{
+				NewPair(1, 111),
+				NewPair(2, 222),
+				NewPair(3, 333),
+			}),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Copy(tt.coll)
+			if !reflect.DeepEqual(got, tt.coll) {
+				t.Errorf("Copy() = %v, want1 %v", got, tt.coll)
+			}
+		})
+	}
+}
+
+func Test_Copy_ofCollectionWithoutInternal(t *testing.T) {
+	t.Run("Copy() on collection without internal", func(t *testing.T) {
+		coll := &baseFakeWithoutInternal[int]{}
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Errorf("Copy() did not panic")
+			}
+			if r != "Copy() requires a collection that implements the baseInternal interface" {
+				t.Errorf("Copy() panicked with wrong error: %v", r)
+			}
+		}()
+		Copy(coll)
+	})
+}

--- a/functions_test.go
+++ b/functions_test.go
@@ -88,7 +88,11 @@ func Test_Copy_forEachFlatCollection(t *testing.T) {
 				t.Errorf("Copy() did not create a deep copy")
 			}
 			if got.Len() == tt.coll.Len() {
-				t.Errorf("Original length changed: got %d, want 3", got.Len())
+				t.Errorf(
+					"Copy length %d should be different from original length %d after modification",
+					got.Len(),
+					tt.coll.Len(),
+				)
 			}
 		})
 	}
@@ -129,6 +133,18 @@ func Test_Copy_forEachMap(t *testing.T) {
 			got := Copy(tt.coll)
 			if !reflect.DeepEqual(got, tt.coll) {
 				t.Errorf("Copy() = %v, want %v", got, tt.coll)
+			}
+
+			tt.coll.Append(NewPair(4, 444))
+			if reflect.DeepEqual(got, tt.coll) {
+				t.Errorf("Copy() did not create a deep copy")
+			}
+			if got.Len() == tt.coll.Len() {
+				t.Errorf(
+					"Copy length %d should be different from original length %d after modification",
+					got.Len(),
+					tt.coll.Len(),
+				)
 			}
 		})
 	}

--- a/map.go
+++ b/map.go
@@ -325,7 +325,7 @@ func (c *comfyMap[K, V]) Values() iter.Seq[Pair[K, V]] {
 // Private functions:
 
 //nolint:unused
-func (c *comfyMap[K, V]) copy() mapInternal[K, V] {
+func (c *comfyMap[K, V]) copy() baseInternal[Pair[K, V]] {
 	newCm := &comfyMap[K, V]{
 		s:  []Pair[K, V](nil),
 		m:  make(map[K]Pair[K, V]),

--- a/mapcmp.go
+++ b/mapcmp.go
@@ -407,7 +407,7 @@ func (c *comfyCmpMap[K, V]) Values() iter.Seq[Pair[K, V]] {
 
 // Private:
 
-func (c *comfyCmpMap[K, V]) copy() mapInternal[K, V] {
+func (c *comfyCmpMap[K, V]) copy() baseInternal[Pair[K, V]] {
 	newCm := NewCmpMap[K, V]().(*comfyCmpMap[K, V])
 	for _, pair := range c.s {
 		newCm.set(pair.copy())

--- a/sequence.go
+++ b/sequence.go
@@ -12,7 +12,7 @@ type comfySeq[V any] struct {
 // NewSequence creates a new LinearMutable instance.
 func NewSequence[V any]() Sequence[V] {
 	return &comfySeq[V]{
-		s: make([]V, 0),
+		s: []V(nil),
 	}
 }
 
@@ -257,7 +257,7 @@ func (c *comfySeq[V]) Values() iter.Seq[V] {
 // Private:
 
 //nolint:unused
-func (c *comfySeq[V]) copy() Base[V] {
+func (c *comfySeq[V]) copy() baseInternal[V] {
 	newCl := &comfySeq[V]{
 		s: []V(nil),
 	}

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -96,7 +96,7 @@ func TestNewSequence(t *testing.T) {
 		if intSeq == nil {
 			t.Error("NewSequence[int]() returned nil")
 		}
-		if !reflect.DeepEqual(intSeq, &comfySeq[int]{s: make([]int, 0)}) {
+		if !reflect.DeepEqual(intSeq, &comfySeq[int]{s: []int(nil)}) {
 			t.Error("NewSequence[int]() did not return a comfySeq[int]")
 		}
 
@@ -104,7 +104,7 @@ func TestNewSequence(t *testing.T) {
 		if stringSeq == nil {
 			t.Error("NewSequence[string]() returned nil")
 		}
-		if !reflect.DeepEqual(stringSeq, &comfySeq[string]{s: make([]string, 0)}) {
+		if !reflect.DeepEqual(stringSeq, &comfySeq[string]{s: []string(nil)}) {
 			t.Error("NewSequence[int]() did not return a comfySeq[int]")
 		}
 	})

--- a/sequencecmp.go
+++ b/sequencecmp.go
@@ -349,7 +349,7 @@ func (c *comfyCmpSeq[V]) Values() iter.Seq[V] {
 }
 
 //nolint:unused
-func (c *comfyCmpSeq[V]) copy() Base[V] {
+func (c *comfyCmpSeq[V]) copy() baseInternal[V] {
 	ccl := &comfyCmpSeq[V]{
 		s:  []V(nil),
 		vc: newValuesCounter[V](),


### PR DESCRIPTION
This PR focuses on refactoring the Copy() function implementation and making the internal interfaces more consistent, while removing unused code.

- Modify Copy() to check for baseInternal interface implementation
- Update copy() method signatures to return baseInternal[V] consistently
- Remove unused KV-related types and functions
- Remove comfyContainsValue and comfyContainsKV functions
- Initialize empty slices with nil instead of make()
- Add test cases for Copy() function and edge cases
- Update interface definitions for mapInternal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to validate correct behavior when evaluating collections in reversed order.
  - Introduced comprehensive unit tests for various collection operations, ensuring correct behavior of the `Copy` function.

- **Refactor**
  - Enhanced collection operations with improved type safety and error management.
  - Streamlined the internal code by removing deprecated helper components, resulting in a more consistent and robust experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->